### PR TITLE
kenzo: rootdir: fix typo

### DIFF
--- a/rootdir/etc/init.kenzo.rc
+++ b/rootdir/etc/init.kenzo.rc
@@ -27,7 +27,7 @@
 #
 #
 
-on post-fs data
+on post-fs-data
     mkdir /data/goodix 0700 system system
 
 on boot


### PR DESCRIPTION
* [12.597787] init: /vendor/etc/init/init.kenzo.rc: 30: && is the only symbol allowed to concatenate actions

* seems "-"for post-fs-data was misssed during bringup

Signed-off-by: Adarsh-MR <adarshmr1998@gmail.com>